### PR TITLE
HEAT-55 refactor: :recycle: API요청 로직 분리

### DIFF
--- a/heat-app/components/common/DropDown.tsx
+++ b/heat-app/components/common/DropDown.tsx
@@ -1,7 +1,7 @@
 import ArrowDownIcon from 'public/ArrowDownIcon.svg';
 import { css, useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Text } from './Text';
 import { useMediaQuery } from 'utils/hooks/useMediaQuery';
 
@@ -47,16 +47,6 @@ export const DropdownMenu = styled.ul<DropdownButtonProps>`
     width: ${({ size }) => (size === 'xs' ? '12rem' : '20rem')};
   }
 `;
-
-// export const DropdownItem = styled.li<{ disabled?: boolean }>`
-//   padding: 10px;
-//   padding-left: 10px;
-//   border-radius: 20px;
-//   cursor: pointer;
-//   &:hover {
-//     background-color: ${({ theme }) => theme.colors.mono.input_gray};
-//   }
-// `;
 
 export const DropdownItem = styled.li<{ disabled?: boolean }>`
   padding: 10px;
@@ -182,7 +172,10 @@ const Dropdown = ({
         paddingLeft={paddingLeft}
         paddingRight={paddingRight}
         size={size}
-        onClick={() => setShowDropdown(!showDropdown)}
+        type="button"
+        onClick={() => {
+          setShowDropdown(prev => !prev);
+        }}
       >
         <Text
           fontSize={size === 'xs' ? '1.3rem' : isMobile ? '0.8rem' : '2rem'}

--- a/heat-app/components/pages/login/AvatarUploader.tsx
+++ b/heat-app/components/pages/login/AvatarUploader.tsx
@@ -16,7 +16,7 @@ type FormValues = {
   avatar: FileList | string;
 };
 
-interface AvatarUploaderProps {
+export interface AvatarUploaderProps {
   alt?: string;
   control: Control<FormValues>;
   selectedFile: File | null;

--- a/heat-app/components/pages/login/GoogleLoginButton.tsx
+++ b/heat-app/components/pages/login/GoogleLoginButton.tsx
@@ -20,23 +20,28 @@ export const GoogleLoginButton = ({
   const [token, setToken] = useState(null);
   const [, setToast] = useAtom(toastAtom);
 
+  // 구글 로그인 성공 시 실행되는 함수
   const googleOnSuccess = (data: any) => {
     const access_token = data.access_token;
     setToken(access_token);
   };
+  // 구글 로그인 실패 시 실행되는 함수
   const googleOnError = (error: any) => {
     console.log(error);
   };
 
+  // 구글 로그인을 위한 useGoogleLogin
   const handleLogin = useGoogleLogin({
     onSuccess: googleOnSuccess,
     onError: googleOnError,
   });
 
+  // 구글 로그인을 위한 useMutation
   const googleLoginMutation = useMutation((accessToken: string) =>
     postDataWithBody('/user/login/google', { accessToken: accessToken }),
   );
 
+  // 구글 로그인 성공 시 서버로 토큰을 보내는 함수->성공시 유저 번호를 받아옴
   const sendToken = (token: string) => {
     googleLoginMutation.mutate(token, {
       onSuccess: data => {

--- a/heat-app/components/pages/main/HistoryCard.tsx
+++ b/heat-app/components/pages/main/HistoryCard.tsx
@@ -16,6 +16,7 @@ import { deleteDataWithParams } from 'utils/api/api';
 import apiClient from 'utils/api/apiClient';
 import { toastAtom } from 'utils/jotai/atoms/toastAtom';
 import { useAtom } from 'jotai';
+import { deleteHistory } from 'utils/api/translation/translationAPI';
 
 type HistoryCardProps = {
   data: Translation;
@@ -23,7 +24,6 @@ type HistoryCardProps = {
 };
 export const HistoryCard = ({ data, refetch }: HistoryCardProps) => {
   const [, setToast] = useAtom(toastAtom);
-
   const [isModalOpen, setModalOpen] = useState(false);
   const [isClicked, setIsClicked] = useState(false);
   const theme = useTheme();
@@ -46,6 +46,9 @@ export const HistoryCard = ({ data, refetch }: HistoryCardProps) => {
   const toggleModal = () => {
     setModalOpen(!isModalOpen);
   };
+
+  //history 삭제하는 mutation hook
+  const deleteHistoryMutation = deleteHistory();
 
   const handleDelete = () => {
     deleteHistoryMutation.mutate(translationNo, {
@@ -70,31 +73,7 @@ export const HistoryCard = ({ data, refetch }: HistoryCardProps) => {
       },
     });
   };
-  /**
-   * @description 히스토리 삭제 요청
-   */
-  const deleteHistory = async (endpoint: string, translationNo: number) => {
-    const { data } = await apiClient.delete(
-      `${endpoint}/?translation-no=${translationNo}`,
-    );
-    return data;
-  };
 
-  // const deleteUserGo = async (endpoint: string, userAccountNo: number) => {
-  //   const { data } = await apiClient.delete(
-  //     `${endpoint}/?uid=${userAccountNo}`,
-  //   );
-  //   return data;
-  // };
-  /**
-   * @description 해당 유저 삭제
-   * 해당 값으로 유저 권한 변경
-   * @param userRole
-   */
-  const deleteHistoryMutation = useMutation((translationNo: number) =>
-    // deleteDataWithParams('/translation/translation-no', translationNo),
-    deleteHistory('/translation/translation-no', translationNo),
-  );
   return (
     <>
       <HistoryCardContainer isClicked={isClicked} onClick={handleClick}>

--- a/heat-app/components/pages/main/TranslationHistoryPanel.tsx
+++ b/heat-app/components/pages/main/TranslationHistoryPanel.tsx
@@ -4,7 +4,7 @@ import { HistoryCard } from './HistoryCard';
 import { Text } from 'components/common/Text';
 import { Spacer } from 'components/common/Spacer';
 import Dropdown from 'components/common/DropDown';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Translation } from 'types/schema/Translation';
 import { Skeleton } from 'components/common/Skeleton';
 
@@ -20,11 +20,11 @@ interface TranslationHistoryPanelProps {
 
 export const TranslationHistoryPanel = ({
   historyList,
-  isLoading,
+  isLoading: isDataLoading,
   refetch,
 }: TranslationHistoryPanelProps) => {
   const [selectedOption, setSelectedOption] = useState('new');
-
+  const [isLoading, setIsLoading] = useState(false);
   const sortedHistory = useMemo(() => {
     return historyList?.slice().sort((a, b) => {
       let aDate = new Date(a.createDateTime);
@@ -37,6 +37,22 @@ export const TranslationHistoryPanel = ({
       }
     });
   }, [historyList, selectedOption]);
+
+  useEffect(() => {
+    // 데이터가 로딩 중일 경우 0.5초 후에 로딩 상태를 표시.
+    if (isDataLoading) {
+      const timeoutId = setTimeout(() => {
+        setIsLoading(true);
+      }, 500); //로딩 지연시간 설정
+
+      return () => {
+        clearTimeout(timeoutId);
+      };
+    } else {
+      // 데이터가 로딩완료되면, isLoading을 즉시 false로 설정.
+      setIsLoading(false);
+    }
+  }, [isDataLoading]);
 
   return (
     <HistoryContainer>

--- a/heat-app/pages/index.tsx
+++ b/heat-app/pages/index.tsx
@@ -17,7 +17,7 @@ const HomePage = () => {
   const theme = useTheme();
   const handleStart = () => {
     if (isAuthenticated) {
-      router.push(ROUTES.MAIN(user.userId));
+      router.push(ROUTES.MAIN(user.userAccountNo));
     } else {
       router.push(ROUTES.LOGIN);
     }

--- a/heat-app/utils/api/api.ts
+++ b/heat-app/utils/api/api.ts
@@ -13,6 +13,7 @@ export const getDataWithParams = async (endpoint: string, params: any) => {
   return data;
 };
 
+// GET
 export const getData = async (endpoint: string) => {
   const { data } = await apiClient.get(endpoint);
   return data;

--- a/heat-app/utils/api/formClient.ts
+++ b/heat-app/utils/api/formClient.ts
@@ -1,0 +1,47 @@
+import axios from 'axios';
+import { BACK_END_URL } from './apiClient';
+
+//기본해더가 apllication/json이라서 formdata로 보내면 에러가 난다.
+//그래서 기본해더를 multipart/form-data로 바꿔줘야한다.
+//그리고 withCredentials를 true로 해줘야 쿠키가 전달된다.
+const formClient = axios.create({
+  baseURL: BACK_END_URL,
+  withCredentials: true,
+});
+
+// Request interceptor
+formClient.interceptors.request.use(config => {
+  return config;
+});
+
+// Response interceptor
+formClient.interceptors.response.use(
+  response => {
+    return response;
+  },
+  async error => {
+    const originalRequest = error.config;
+    if (error.response.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true;
+      try {
+        // 쿠키가 있는 경우, 새로운 access token과 refresh token을 요청합.
+        const res = await axios.post(
+          BACK_END_URL + '/refresh-token',
+          {},
+          { withCredentials: true },
+        );
+        // 새로운 accessToken을 이용해 원래의 요청을 다시 수행.
+        originalRequest.headers['Authorization'] =
+          'Bearer ' + res.data.accessToken;
+        return formClient(originalRequest);
+      } catch (err) {
+        // Refresh token이 만료되었거나, 서버에서 refreshToken을 확인할 수 없는 경우, 로그아웃하거나 에러 페이지로 리다이렉트.
+        console.error('Refresh token is invalid. Please log in again.', err);
+      }
+    }
+    // 다른 에러의 경우 axios로 에러를 전달.
+    return Promise.reject(error);
+  },
+);
+
+export default formClient;

--- a/heat-app/utils/api/translation/translationAPI.ts
+++ b/heat-app/utils/api/translation/translationAPI.ts
@@ -1,0 +1,69 @@
+import { useMutation, useQuery } from 'react-query';
+import { getDataWithParams, postDataWithBody } from '../api';
+import { User } from 'types/schema/User';
+import apiClient from '../apiClient';
+
+/**
+ * @description 번역 요청을 위한 useMutation
+ * @param translationData : FormData
+ * @returns
+ */
+export const postFormToTranslation = () => {
+  const data = useMutation((translationData: FormData) =>
+    postDataWithBody('/translation', translationData),
+  );
+  return data;
+};
+
+/**
+ * @description 번역 결과 요청을 위한 useQuery. 번역 번호 상태가 null이 아닐 때에만 실행.
+ * @param translationNo : number
+ * @returns
+ */
+export const getTranslationResult = (translationNo: number | null) => {
+  const data = useQuery(
+    ['getTranslationResult', translationNo],
+    () =>
+      getDataWithParams(`/translation/translation-no`, {
+        'translation-no': translationNo,
+      }),
+    { enabled: translationNo !== null, retry: 10, retryDelay: 5000 },
+  );
+  return data;
+};
+
+/**
+ * @description 드롭다운 메뉴에서 선택시 작동
+ * 1. 해당 값으로 input 값 변경
+ * 2. 드롭다운 닫기
+ * @param searchedUser
+ */
+export const getSearchedUserHistoryResult = (searchedUser: User | null) => {
+  const data = useQuery(
+    ['getSearchedUserHistoryResult', searchedUser],
+    () =>
+      getDataWithParams(`/translation/user-email`, {
+        'user-email': searchedUser?.userEmail,
+      }),
+    { enabled: searchedUser !== null, retry: 5, retryDelay: 5000 },
+  );
+  return data;
+};
+
+/**
+ * @description 해당 유저 삭제
+ * 해당 값으로 유저 권한 변경
+ * @param userRole
+ */
+export const deleteHistory = () => {
+  const deleteHistory = async (endpoint: string, translationNo: number) => {
+    const { data } = await apiClient.delete(
+      `${endpoint}/?translation-no=${translationNo}`,
+    );
+    return data;
+  };
+  const data = useMutation((translationNo: number) =>
+    deleteHistory('/translation/translation-no', translationNo),
+  );
+  return data;
+};

--- a/heat-app/utils/api/user/userAPI.ts
+++ b/heat-app/utils/api/user/userAPI.ts
@@ -1,0 +1,129 @@
+import { useMutation, useQuery } from 'react-query';
+import { getDataWithParams, postDataWithBody } from '../api';
+import formClient from '../formClient';
+import apiClient from '../apiClient';
+
+/**
+ * @description 유저정보 요청을 위한 useQuery. 번역 번호 상태가 null이 아닐 때에만 실행.
+ * userAccountNo가 null이 아닐 때에만 실행되도록 설정.
+ * retry 3번, 3초 간격으로 재시도.
+ * @param resultUserAccountNo : number
+ */
+export const getUserDataResultsLogin = (resultUserAccountNo: number | null) => {
+  const data = useQuery(
+    ['getUserDataResultsLogin', resultUserAccountNo],
+    () =>
+      getDataWithParams(`/user/uid`, {
+        uid: resultUserAccountNo,
+      }),
+    { enabled: resultUserAccountNo !== null, retry: 3, retryDelay: 3000 },
+  );
+  return data;
+};
+
+/**
+ * @description 유저정보 요청을 위한 useQuery.
+ * refetch에의해서만 실행
+ * @param userAccountNo : number
+ */
+export const getUserDataResultsUpdate = (userAccountNo: number | null) => {
+  const data = useQuery(
+    ['getUserDataResultsUpdate', userAccountNo],
+    () =>
+      getDataWithParams(`/user/uid`, {
+        uid: userAccountNo,
+      }),
+    { enabled: false },
+  );
+  return data;
+};
+
+/**
+ * @description 로그인 요청을 위한 useMutation
+ * @param FormData
+ * retry 3번, 1초 간격으로 재시도.
+ * @returns tokens + userAccountNo
+ */
+export const postFormToLogin = () => {
+  const data = useMutation(
+    (userData: FormData) => postDataWithBody('/user/login', userData),
+    { retry: 3, retryDelay: 1000 },
+  );
+  return data;
+};
+
+/**
+ * @description 회원가입 요청을 위한 useMutation
+ * @param FormData
+ * @returns
+ */
+export const postFormToRegister = () => {
+  const data = useMutation((userData: FormData) =>
+    formClient.post('/user', userData),
+  );
+  return data;
+};
+
+/**
+ * @description 유저 정보 수정을 위한 useMutation
+ * @param FormData
+ * @returns
+ */
+export const postFormToUpdate = () => {
+  const data = useMutation((userData: FormData) =>
+    formClient.patch('/user', userData),
+  );
+  return data;
+};
+
+/**
+ * @description username기반 쿼리 요청
+ * 실제 백엔드에 유저 리스트를 검색
+ * @param debouncedSearchValue
+ */
+export const getDebounceList = (debouncedSearchValue: string) => {
+  const data = useQuery(
+    ['getDebounceList', debouncedSearchValue],
+    () =>
+      getDataWithParams(`/user/list/`, {
+        username: debouncedSearchValue,
+      }),
+    { enabled: debouncedSearchValue !== null && debouncedSearchValue !== '' },
+  );
+  return data;
+};
+
+/**
+ * @description username기반 쿼리 요청
+ * 실제 백엔드에 특정 유저를 검색
+ * @param usernameInput
+ */
+export const getSelectedUserData = (usernameInput: string) => {
+  const data = useQuery(
+    ['getSelectUser', usernameInput],
+    () =>
+      getDataWithParams(`/user/list/`, {
+        username: usernameInput,
+      }),
+    { enabled: false },
+  );
+  return data;
+};
+
+/**
+ * @description 해당 유저 삭제
+ * 해당 값으로 유저 권한 변경
+ * @param userRole
+ */
+export const deleteUserMutation = () => {
+  const deleteUser = async (endpoint: string, userAccountNo: number) => {
+    const { data } = await apiClient.delete(
+      `${endpoint}/?uid=${userAccountNo}`,
+    );
+    return data;
+  };
+  const data = useMutation((userAccountNo: number) =>
+    deleteUser('/admin/user', userAccountNo),
+  );
+  return data;
+};


### PR DESCRIPTION
API요청 로직이 컴포넌트 내부에 너무 많은 설정과함께 존재할경우 코드 가독성이 떨어져서 따로 분리했습니다.

```
utils
├── api
│   ├── apiClient.ts     // axios의 기본 인스턴스 설정 
│   ├── formClient.ts    // formData 전송을 위한 별도의 axios 인스턴스 설정 파일
│   ├── api.ts           // apiClient와 formClient를 import하여 사용하는 공통 API 호출 함수 모아놓은 파일
│   ├── user
│   │   └── userAPI.ts   // user 관련 API 호출 함수 모아놓은 파일
│   └── translation
│       └── translationAPI.ts // translation 관련 API 호출 함수 모아놓은 파일.
```