### PR TITLE
HEAT-60 feat: :sparkles: 번역결과 재시도 조건 변경

### DIFF
--- a/heat-app/utils/api/translation/translationAPI.ts
+++ b/heat-app/utils/api/translation/translationAPI.ts
@@ -29,7 +29,10 @@ export const getTranslationResult = (translationNo: number | null) => {
       }),
     {
       enabled: translationNo !== null,
-      retry: 10,
+      retry: (failureCount, error: { response: { status: number } }) => {
+        // HTTP 상태 코드가 202이면 재시도
+        return error.response.status === 202;
+      },
       retryDelay: attemptIndex =>
         attemptIndex < 5 ? 1000 : (attemptIndex - 4) * 1000,
     },


### PR DESCRIPTION
202번에 한해서 요청하도록 번경

```/**
 * @description 번역 결과 요청을 위한 useQuery. 번역 번호 상태가 null이 아닐 때에만 실행.
 * @param translationNo : number
 * @returns
 */
export const getTranslationResult = (translationNo: number | null) => {
  const data = useQuery(
    ['getTranslationResult', translationNo],
    () =>
      getDataWithParams(`/translation/translation-no`, {
        'translation-no': translationNo,
      }),
    {
      enabled: translationNo !== null,
      retry: (failureCount, error: { response: { status: number } }) => {
        // HTTP 상태 코드가 202이면 재시도
        return error.response.status === 202;
      },
      retryDelay: attemptIndex =>
        attemptIndex < 5 ? 1000 : (attemptIndex - 4) * 1000,
    },
  );
  return data;
};
```