### PR TITLE
HEAT-66 feat: :sparkles: languageList 받아와서 설정

### DIFF
--- a/heat-app/components/common/DropDown.tsx
+++ b/heat-app/components/common/DropDown.tsx
@@ -149,7 +149,7 @@ const Dropdown = ({
   value,
   onChange,
   size,
-  placeholder = 'Select your first language',
+  placeholder = 'Select default language',
   paddingLeft = '1.5rem',
   paddingRight = '1.5rem',
 }: DropdownProps) => {

--- a/heat-app/components/pages/login/RegisterModal.tsx
+++ b/heat-app/components/pages/login/RegisterModal.tsx
@@ -187,15 +187,18 @@ const RegisterModal = ({ isModalOpen, toggleModal }: ModalContainerProps) => {
               <Controller
                 control={control}
                 name="language"
-                rules={{ required: 'First language is required' }}
+                rules={{ required: 'Default language is required' }}
                 render={({ field }) => (
                   <HStack>
                     <Dropdown
-                      placeholder="Select your first language"
+                      placeholder="Select default language"
                       size={'lg'}
                       options={[
-                        { label: 'Select your first language', value: '' },
-                        ...languageList,
+                        { label: 'Select default language', value: '' },
+                        ...languageList.map(languageDto => ({
+                          label: languageDto.languageName,
+                          value: languageDto.languageName,
+                        })),
                       ]}
                       value={field.value}
                       onChange={field.onChange}

--- a/heat-app/components/pages/main/UpdateModal.tsx
+++ b/heat-app/components/pages/main/UpdateModal.tsx
@@ -38,7 +38,9 @@ const UpdateModal = ({ isModalOpen, toggleModal }: ModalContainerProps) => {
   const [user, setUser] = useAtom(userAtom);
   const [, setToast] = useAtom(toastAtom);
   const [changePassword, setChangePassword] = useState(false);
-
+  const [selectedLanguage, setSelectedLanguage] = useState(
+    user.languageName || 'English',
+  );
   //제출 폼 관련
   const {
     register,
@@ -119,6 +121,7 @@ const UpdateModal = ({ isModalOpen, toggleModal }: ModalContainerProps) => {
   // 모달이 닫힐 때마다 폼을 리셋해준다.
   useEffect(() => {
     if (!isModalOpen) {
+      setSelectedLanguage(user.languageName);
       reset({
         email: user.userEmail,
         username: user.userName,
@@ -186,18 +189,21 @@ const UpdateModal = ({ isModalOpen, toggleModal }: ModalContainerProps) => {
               <Controller
                 control={control}
                 name="language"
-                rules={{ required: 'First language is required' }}
+                rules={{ required: 'Default language is required' }}
                 render={({ field }) => (
                   <HStack>
                     <Dropdown
-                      placeholder="Select your first language"
+                      placeholder="Select default language"
                       size={'lg'}
                       options={[
-                        { label: 'Select your first language', value: '' },
-                        ...languageList,
+                        { label: 'Select default language', value: '' },
+                        ...languageList.map(languageDTO => ({
+                          label: languageDTO.languageName,
+                          value: languageDTO.languageName,
+                        })),
                       ]}
-                      value={field.value}
-                      onChange={field.onChange}
+                      value={selectedLanguage}
+                      onChange={setSelectedLanguage}
                     />
                   </HStack>
                 )}

--- a/heat-app/pages/login/index.tsx
+++ b/heat-app/pages/login/index.tsx
@@ -18,11 +18,13 @@ import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { ROUTES } from 'utils/ROUTES';
+import { getLanguageList } from 'utils/api/language/languageAPI';
 import {
   getUserDataResultsLogin,
   postFormToLogin,
 } from 'utils/api/user/userAPI';
 import { isAuthenticatedAtom } from 'utils/jotai/atoms/isAuthenticatedAtom';
+import { languageListAtom } from 'utils/jotai/atoms/languageListAtom';
 import { toastAtom } from 'utils/jotai/atoms/toastAtom';
 import { defaultUser, userAtom } from 'utils/jotai/atoms/userAtom';
 
@@ -37,6 +39,7 @@ const Login = () => {
   const theme = useTheme();
   const router = useRouter();
   const [isModalOpen, setModalOpen] = useState(false);
+  const [, setLanguageList] = useAtom(languageListAtom);
   const [, setToast] = useAtom(toastAtom);
   const [resultUserAccountNo, setResultUserAccountNo] = useState<number | null>(
     null,
@@ -87,10 +90,17 @@ const Login = () => {
   //axios 요청 관련
   const { data: userResultData } = getUserDataResultsLogin(resultUserAccountNo);
   const { mutate: loginMutate } = postFormToLogin();
+  const { data: languageList } = getLanguageList();
 
   /**
-   * @description userResultData가 존재하면 userAtom에 저장하고 로그인 성공 후 메인으로 이동
+   * @description languageList가 존재하면 languageListAtom에 저장
    */
+  useEffect(() => {
+    if (languageList) {
+      setLanguageList(languageList);
+    }
+  }, [languageList]);
+
   useEffect(() => {
     if (userResultData) {
       setUser(userResultData);

--- a/heat-app/pages/main/[uid].tsx
+++ b/heat-app/pages/main/[uid].tsx
@@ -30,7 +30,6 @@ const MainPage = () => {
   const [, setIsSidebarOpen] = useAtom(isSidebarOpenAtom);
   const isMobile = useMediaQuery(theme.Media.mobile_query);
   const { uid } = router.query;
-  const [selectedLanguage, setSelectedLanguage] = useState('English');
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const [inputText, setInputText] = useState('');
   const [outputText, setOutputText] = useState('');
@@ -39,7 +38,10 @@ const MainPage = () => {
   const [languageList] = useAtom(languageListAtom);
   const [loadingText, setLoadingText] = useState('loading');
   const [, setIsAuthenticated] = useAtom(isAuthenticatedAtom);
-  const [, setUser] = useAtom(userAtom);
+  const [user, setUser] = useAtom(userAtom);
+  const [selectedLanguage, setSelectedLanguage] = useState(
+    user.languageName || 'English',
+  );
 
   // 번역 요청을 위한 useMutation
   const translationMutaion = postFormToTranslation();
@@ -73,6 +75,7 @@ const MainPage = () => {
   const clearInputOutput = () => {
     setInputText('');
     setOutputText('');
+    setSelectedLanguage(user.languageName || 'English');
   };
 
   // 로딩 중일 때 실행되는 useEffect
@@ -141,7 +144,12 @@ const MainPage = () => {
               <HStack w="100%" spacing={isMobile ? '1rem' : '2rem'}>
                 <StyledText>TO</StyledText>
                 <Dropdown
-                  options={languageList}
+                  options={[
+                    ...languageList.map(languageDTO => ({
+                      label: languageDTO.languageName,
+                      value: languageDTO.languageName,
+                    })),
+                  ]}
                   value={selectedLanguage}
                   onChange={setSelectedLanguage}
                   paddingLeft="1rem"

--- a/heat-app/utils/api/language/languageAPI.ts
+++ b/heat-app/utils/api/language/languageAPI.ts
@@ -1,0 +1,7 @@
+import { useQuery } from 'react-query';
+import { getData } from '../api';
+
+export const getLanguageList = () => {
+  const data = useQuery('getLanguageList', () => getData('/language'));
+  return data;
+};

--- a/heat-app/utils/jotai/atoms/languageListAtom.ts
+++ b/heat-app/utils/jotai/atoms/languageListAtom.ts
@@ -1,18 +1,6 @@
 import { atom } from 'jotai';
 
-export const languageListAtom = atom([
-  // { label: 'Select your first language', value: '' },
-  { label: 'Korean', value: 'Korean' },
-  { label: 'English', value: 'English' },
-  { label: 'Chinese', value: 'Chinese' },
-  { label: 'Spanish', value: 'Spanish' },
-  { label: 'Portuguese', value: 'Portuguese' },
-  { label: 'German', value: 'German' },
-  { label: 'Czech', value: 'Czech' },
-  { label: 'Slovak', value: 'Slovak' },
-  { label: 'Russian', value: 'Russian' },
-  { label: 'Hindi', value: 'Hindi' },
-  { label: 'Indonesian', value: 'Indonesian' },
-  { label: 'Arabic', value: 'Arabic' },
-  { label: 'Vietnamese', value: 'Vietnamese' },
-]);
+type LanguageDto = {
+  languageName: string;
+};
+export const languageListAtom = atom<LanguageDto[]>([]);


### PR DESCRIPTION
서비스 중인 언어 목록을 받아와서 세팅하도록 설정
현재 13개국 언어 지원중
```
-> <GET> BACK_END_URL + 'language'
= [
    {
        "languageName": "Korean"
    },
    {
        "languageName": "English"
    },
    {
        "languageName": "Chinese"
    },
    {
        "languageName": "Spanish"
    },
    {
        "languageName": "Portuguese"
    },
    {
        "languageName": "German"
    },
    {
        "languageName": "Czech"
    },
    {
        "languageName": "Slovak"
    },
    {
        "languageName": "Russian"
    },
    {
        "languageName": "Hindi"
    },
    {
        "languageName": "Indonesian"
    },
    {
        "languageName": "Arabic"
    },
    {
        "languageName": "Vietnamese"
    }
]
```